### PR TITLE
Improve readme, disable prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# screeps-starter-rust
+# screeps-arena-starter-rust
 
-Starter Rust AI for [Screeps][screeps], the JavaScript-based MMO game.
+Starter Rust AI for [Screeps: Arena][screeps-arena], the JavaScript-based programming
+strategy game.
 
-This uses the [`screeps-game-api`] bindings from the [rustyscreeps] organization.
+This uses the [`screeps-arena-game-api`] bindings from the [rustyscreeps] organization.
 
-It's also recommended to use [`cargo-screeps`] for uploading the code.
+It's also recommended to use [`cargo-screeps`] for building the code.
 
 The documentation is currently a bit sparse. API docs which list functions one
-can use are located at https://docs.rs/screeps-game-api/.
+can use are located at https://docs.rs/screeps-arena-game-api/.
 
 Almost all crates on https://crates.io/ are usable (only things which interact with OS
 apis are broken).
@@ -18,8 +19,8 @@ Quickstart:
 # cli dependencies:
 # TEMPORARY - get the arena branch of the cargo-screeps tool, which supports arena
 git clone https://github.com/rustyscreeps/cargo-screeps.git
-git checkout arena
 cd cargo-screeps
+git checkout arena
 cargo install --path .
 cd ..
 # TEMPORARY once arena is merged, go back to simply:
@@ -28,10 +29,8 @@ cargo install cargo-screeps
 # clone:
 git clone https://github.com/rustyscreeps/screeps-arena-starter-rust.git
 cd screeps-starter-rust
-# TEMPORARY
-git checkout arena
 
-# configure for uploading:
+# configure with the path to your arena code directory:
 cp example-screeps.toml screeps.toml
 nano screeps.toml
 
@@ -39,11 +38,11 @@ nano screeps.toml
 cargo screeps --help
 # compile the module
 cargo screeps build
-# compile plus deploy to the configured 'ctf' mode
-cargo screeps deploy -m ctf
+# compile plus deploy code to the game directory for the Swamp & Spawn arena
+cargo screeps deploy -m swamp
 ```
 
-[screeps]: https://screeps.com/
+[screeps-arena]: https://store.steampowered.com/app/1137320/Screeps_Arena/
 [`cargo-screeps`]: https://github.com/rustyscreeps/cargo-screeps/
-[`screeps-game-api`]: https://github.com/rustyscreeps/screeps-game-api/
+[`screeps-arena-game-api`]: https://github.com/rustyscreeps/screeps-arena-game-api/
 [rustyscreeps]: https://github.com/rustyscreeps/

--- a/example-screeps.toml
+++ b/example-screeps.toml
@@ -5,21 +5,21 @@ build_mode = "arena"
 
 [ctf]
 destination = "/Users/username/ScreepsArena"
-prune = true
+prune = false
 branch = "alpha-capture_the_flag"
   [ctf.build]
   extra_options = ["--features=arena-capture-the-flag"]
 
 [swamp]
 destination = "/Users/username/ScreepsArena"
-prune = true
+prune = false
 branch = "alpha-spawn_and_swamp"
   [swamp.build]
   extra_options = ["--features=arena-spawn-and-swamp"]
 
 [collect]
 destination = "/Users/username/ScreepsArena"
-prune = true
+prune = false
 branch = "alpha-collect_and_control"
   [collect.build]
   extra_options = ["--features=arena-collect-and-control"]


### PR DESCRIPTION
`prune` mode is broken for arena right now due to the developers adding typescript bindings to the user code directory; cargo-screeps needs a fix.

Fixed a number of clarity issues in the readme and updated to reference the correct game.